### PR TITLE
Replaced jcenter by jitpack.io for android accept sdk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ First go to android/app/build.gradle  in in the android {} block add
 
 ```
     repositories {
-        jcenter()
+        maven { url "https://jitpack.io" }
+
     }
 
     dependencies {
-        implementation 'net.authorize:accept-sdk-android:1.0.2'
+        implementation 'com.github.AuthorizeNet:accept-sdk-android:1.04'
     }
 ```
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,8 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url "https://jitpack.io" }
+
     }
 
     dependencies {
@@ -25,13 +27,13 @@ android {
     compileSdkVersion 30
 
     repositories {
-        jcenter()
+        maven { url "https://jitpack.io" }
     }
 
     dependencies {
-        implementation 'net.authorize:accept-sdk-android:1.0.2'
+        implementation 'com.github.AuthorizeNet:accept-sdk-android:1.04'
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 26
     }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,11 +26,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     repositories {
-        jcenter()
+        maven { url "https://jitpack.io" }
     }
 
     dependencies {
-        implementation 'net.authorize:accept-sdk-android:1.0.2'
+        implementation 'com.github.AuthorizeNet:accept-sdk-android:1.04'
     }
 
     compileSdkVersion 31
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.jparrack.authorize_net_plugin_example"
-        minSdkVersion 16
+        minSdkVersion 26
         targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
1. Replaced jcenter by [jitpack](https://jitpack.io). Authorize
2. Updated the `minSdkVersion` to 26 to match the accept SDK `1.0.4`.
3. Updated the guidelines in readme.